### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/stealth-service/migros.py
+++ b/stealth-service/migros.py
@@ -111,12 +111,12 @@ async def _handle_cookie_consent(page: Page) -> None:
 
 async def _find_first_visible(page: Page, selectors: tuple[str, ...], timeout_ms: int):
     per_selector_timeout = min(5000, max(1200, timeout_ms // max(len(selectors), 1)))
-    for selector in selectors:
+    for index, selector in enumerate(selectors, start=1):
         locator = page.locator(selector).first
         try:
             await locator.wait_for(timeout=per_selector_timeout)
             if await locator.is_visible():
-                log.debug("Using selector: %s", selector)
+                log.debug("Using selector at index %d of %d", index, len(selectors))
                 return locator
         except Exception:  # noqa: BLE001
             continue


### PR DESCRIPTION
Potential fix for [https://github.com/patbaumgartner/swiss-coupon-booster/security/code-scanning/9](https://github.com/patbaumgartner/swiss-coupon-booster/security/code-scanning/9)

General fix: avoid logging raw untrusted selector strings; log only non-sensitive metadata (e.g., index/count) or a constant message.

Best single fix here: in `stealth-service/migros.py`, update `_find_first_visible` so the debug message does not include `selector`. Replace it with a count/index-based message. This preserves behavior and observability (you still know a selector matched) while preventing clear-text emission of potentially sensitive selector values. No import or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
