### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/stealth-service/migros.py
+++ b/stealth-service/migros.py
@@ -142,12 +142,16 @@ async def _is_visible(page: Page, selector: str) -> bool:
 
 
 async def _switch_to_password_mode_if_available(page: Page) -> None:
-    for selector in _MIGROS_PASSWORD_LINK_SELECTORS:
+    for index, selector in enumerate(_MIGROS_PASSWORD_LINK_SELECTORS, start=1):
         locator = page.locator(selector).first
         try:
             await locator.wait_for(timeout=4000)
             if await locator.is_visible():
-                log.debug("Switching to password mode via selector: %s", selector)
+                log.debug(
+                    "Switching to password mode via selector candidate %d of %d",
+                    index,
+                    len(_MIGROS_PASSWORD_LINK_SELECTORS),
+                )
                 await locator.click()
                 await page.wait_for_load_state("load")
                 return


### PR DESCRIPTION
Potential fix for [https://github.com/patbaumgartner/swiss-coupon-booster/security/code-scanning/10](https://github.com/patbaumgartner/swiss-coupon-booster/security/code-scanning/10)

General fix: avoid logging raw externally sourced values that may be considered sensitive; log non-sensitive metadata instead (e.g., index/count, success/failure state), or redact.

Best fix here (without changing behavior): in `stealth-service/migros.py`, update `_switch_to_password_mode_if_available` so the debug message does **not** include `%s, selector`. Replace it with index/count-based context like “attempt X of Y”. This keeps diagnostic value while eliminating clear-text output of tainted input and should address all three alert variants at the same sink.

Required changes:
- File: `stealth-service/migros.py`
- Region: function `_switch_to_password_mode_if_available`, around current lines 144–151.
- Code edits:
  - change loop to `enumerate(..., start=1)` so we can log index and total.
  - replace `log.debug("Switching to password mode via selector: %s", selector)` with a non-sensitive message using index/count only.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
